### PR TITLE
Use GDAL's internal version of libtiff for jpeg support.

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -124,7 +124,8 @@
                 {
                     "name" : "gdal",
                     "config-opts" : [
-                        "--with-python=python3"
+                        "--with-python=python3",
+                        "--with-libtiff=internal"
                     ],
                     "sources" : [
                         {


### PR DESCRIPTION
I ran into a small issue where TIFF files with JPEG compression couldn't be loaded by QGIS. The specific error message was "cannot open TIFF file due to missing codec". This MR adds a second config option that directs GDAL to use its internal version.