### PR TITLE
Add more GDAL format support

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -72,6 +72,7 @@
                 {
                     "name" : "spatialite",
                     "config-opts" : [
+                        "prefix=/app",
                         "--enable-libxml2",
                         "CFLAGS=-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1"
                     ],
@@ -122,21 +123,66 @@
                     ]
                 },
                 {
+                    "name" : "unixodbc",
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "http://www.unixodbc.org/unixODBC-2.3.7.tar.gz",
+                            "sha256" : "45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77"
+                        }
+                    ]
+                },
+                {
+                    "name": "zstd",
+                    "buildsystem": "cmake-ninja",
+                    "config-opts": [ "-DCMAKE_BUILD_TYPE=Release" ],
+                    "subdir": "build/cmake",
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/facebook/zstd.git",
+                            "branch" : "v1.4.4"
+                        }
+                    ]
+                },
+                {
                     "name" : "gdal",
                     "config-opts" : [
                         "--with-python=python3",
                         "--with-libtiff=internal",
                         "--with-netcdf",
                         "--with-sqlite3",
-                        "--with-geotiff",
+                        "--with-geotiff=internal",
                         "--with-mysql",
                         "--with-curl",
+                        "--with-hdf4",
                         "--with-hdf5",
                         "--with-geos",
                         "--with-png",
                         "--with-poppler",
-                        "--with-spatialite",
-                        "--with-openjpeg"
+                        "--with-spatialite=/app",
+                        "--with-openjpeg",
+                        "--with-hide-internal-symbols",
+                        "--with-bsb",
+                        "--with-grib",
+                        "--with-pam",
+                        "--with-pcre",
+                        "--with-threads=yes",
+                        "--with-liblzma=yes",
+                        "--with-pcidsk=internal",
+                        "--with-pcraster=internal",
+                        "--with-qhull=internal",
+                        "--with-cryptopp",
+                        "--with-crypto",
+                        "--with-cfitsio",
+                        "--with-xerces=/app",
+                        "--with-odbc",
+                        "--with-epsilon",
+                        "--with-rename-internal-libtiff-symbols",
+                        "--with-rename-internal-libgeotiff-symbols",
+                        "--with-jpeg12",
+                        "--with-armadillo",
+                        "--with-libkml=/app"
                     ],
                     "sources" : [
                         {
@@ -167,27 +213,289 @@
                             ]
                         },
                         {
-                        "name" : "hdf5",
-                        "no-autogen" : true,
-                        "sources" : [
-                            {
-                            "type" : "archive",
-                            "url" : "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.bz2",
-                            "sha256" : "09d6301901685201bb272a73e21c98f2bf7e044765107200b01089104a47c3bd"
-                        }
+                            "name" : "xerces-c",
+                            "no-autogen" : true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.2.2.tar.gz",
+                                    "sha256" : "dd6191f8aa256d3b4686b64b0544eea2b450d98b4254996ffdfe630e0c610413"
+                                }
                             ]
                         },
                         {
-                        "name" : "netcdf",
-                        "no-autogen" : true,
-                        "sources" : [
-                            {
-                                "type" : "git",
-                                "url" : "https://github.com/Unidata/netcdf-c.git",
-                                "branch": "v4.7.4"
-                            }
-                        ]
-                    }
+                            "name" : "szip",
+                            "no-autogen" : true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://support.hdfgroup.org/ftp/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz",
+                                    "sha256" : "21ee958b4f2d4be2c9cabfa5e1a94877043609ce86fde5f286f105f7ff84d412"
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "hdf4",
+                            "rm-configure": true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://support.hdfgroup.org/ftp/HDF/releases/HDF4.2.15/src/hdf-4.2.15.tar.gz",
+                                    "sha256" : "dbeeef525af7c2d01539906c28953f0fdab7dba603d1bc1ec4a5af60d002c459"
+                                },
+                                {
+                                    "type": "script",
+                                    "dest-filename": "autogen.sh",
+                                    "commands": [
+                                        "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+                                    ]
+                                }
+                            ],
+                            "config-opts" : [
+                                "--enable-hdf4-xdr",
+                                "--enable-shared",
+                                "--disable-static",
+                                "--disable-fortran",
+                                "--disable-netcdf"
+                            ]
+                        },
+                        {
+                            "name" : "hdf5",
+                            "no-autogen" : true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.bz2",
+                                    "sha256" : "09d6301901685201bb272a73e21c98f2bf7e044765107200b01089104a47c3bd"
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "netcdf",
+                            "no-autogen" : true,
+                            "sources" : [
+                                {
+                                    "type" : "git",
+                                    "url" : "https://github.com/Unidata/netcdf-c.git",
+                                    "branch": "v4.7.4"
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "uriparser",
+                            "buildsystem": "cmake-ninja",
+                            "config-opts": [ 
+                                "-DURIPARSER_BUILD_TESTS=OFF",
+                                "-DURIPARSER_BUILD_DOCS=OFF"
+                            ],
+                            "builddir": true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://github.com/uriparser/uriparser/releases/download/uriparser-0.9.3/uriparser-0.9.3.tar.bz2",
+                                    "sha256" : "28af4adb05e811192ab5f04566bebc5ebf1c30d9ec19138f944963d52419e28f"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "minizip",
+                            "subdir": "contrib/minizip",
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://zlib.net/zlib-1.2.11.tar.gz",
+                                    "md5": "1c9f62f0778697a09d36121ead88e08e"
+                                },
+                                {
+                                    "type": "script",
+                                    "dest-filename": "contrib/minizip/autogen.sh",
+                                    "commands": [
+                                        "autoreconf -ifv"
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cfitsio",
+                            "buildsystem": "simple",
+                            "build-commands": [
+                                "./configure --prefix=${FLATPAK_DEST} --enable-reentrant",
+                                "make shared",
+                                "make install"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-3.47.tar.gz",
+                                    "sha256": "418516f10ee1e0f1b520926eeca6b77ce639bed88804c7c545e74f26b3edf4ef"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "epsilon",
+                            "buildsystem": "simple",
+                            "build-commands": [
+                                "./configure --prefix=${FLATPAK_DEST} --disable-debug --disable-dependency-tracking",
+                                "make install"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://downloads.sourceforge.net/project/epsilon-project/epsilon/0.9.2/epsilon-0.9.2.tar.gz",
+                                    "sha256": "5421a15969d4d7af0ac0a11d519ba8d1d2147dc28d8c062bf0c52f3a0d4c54c4"
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "armadillo",
+                            "buildsystem": "cmake-ninja",
+                            "config-opts": [ 
+                                "-DDETECT_HDF5=ON"
+                            ],
+                            "builddir": true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://downloads.sourceforge.net/project/arma/armadillo-9.850.1.tar.xz",
+                                    "sha256" : "d4c389b9597a5731500ad7a2656c11a6031757aaaadbcafdea5cc8ac0fd2c01f"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cryptopp",
+                            "buildsystem": "simple",
+                            "build-commands": [
+                                "make shared all",
+                                "make install PREFIX=${FLATPAK_DEST}"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://github.com/weidai11/cryptopp/archive/CRYPTOPP_8_1_0.tar.gz",
+                                    "sha256": "8a4e4773a39b0c07d7cea1b8be7a3f7a9d126bd3ac9a9f072f82d3a53a474a87"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "boost",
+                            "buildsystem": "simple",
+                            "build-commands": [
+                                "./bootstrap.sh --prefix=${FLATPAK_DEST}",
+                                "./b2 -j ${FLATPAK_BUILDER_N_JOBS} headers",
+                                "cp -r boost ${FLATPAK_DEST}/include/boost"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2",
+                                    "sha256": "430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778"
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "libkml",
+                            "buildsystem": "cmake-ninja",
+                            "builddir": true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://github.com/libkml/libkml/archive/1.3.0.tar.gz",
+                                    "sha256" : "8892439e5570091965aaffe30b08631fdf7ca7f81f6495b4648f0950d7ea7963"
+                                }
+                            ]
+                        },
+                        {
+                            "name" : "netcdf",
+                            "no-autogen" : true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://github.com/Unidata/netcdf-c/archive/v4.7.3.tar.gz",
+                                    "sha256" : "05d064a2d55147b83feff3747bea13deb77bef390cb562df4f9f9f1ce147840d"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "openjpeg2",
+                            "buildsystem": "cmake-ninja",
+                            "builddir": true,
+                            "sources": [ { "type": "git", "url": "https://github.com/uclouvain/openjpeg.git", "branch": "v2.3.1" } ],
+                            "cleanup": [ "/bin", "/include", "/lib/openjpeg-*", "/lib/pkgconfig" ]
+                        },
+
+                        {
+                            "name": "poppler",
+                            "modules": [
+                                {
+                                    "name": "popplerdata",
+                                    "buildsystem": "cmake-ninja",
+                                    "builddir": true,
+                                    "sources": [
+                                        {
+                                            "type": "archive",
+                                            "url": "https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz",
+                                            "sha256": "1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "config-opts": [ 
+                                "-DCMAKE_BUILD_TYPE=Release",
+                                "-DENABLE_TESTING=OFF",
+                                "-DENABLE_UNSTABLE_API_ABI_HEADERS=ON",
+                                "-DENABLE_CPP=ON",
+                                "-DENABLE_GLIB=OFF",
+                                "-DENABLE_GOBJECT_INTROSPECTION=OFF",
+                                "-DENABLE_UTILS=OFF",
+                                "-DENABLE_LIBOPENJPEG=openjpeg2"
+                            ],
+                            "cleanup": [ "/bin", "/share" ],
+                            "buildsystem": "cmake-ninja",
+                            "builddir": true,
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://poppler.freedesktop.org/poppler-0.86.0.tar.xz",
+                                    "sha256": "6ae8a0b9fde8718025e0034448329efe5fd38194a32ac38f84a1528203c1f9bc"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "mysql-client",
+                            "config-opts": [ 
+                                "-DCMAKE_BUILD_TYPE=Release",
+                                "-DFORCE_INSOURCE_BUILD=1",
+                                "-DWITH_EDITLINE=bundled",
+                                "-DWITH_SSL=yes",
+                                "-DWITH_UNIT_TESTS=OFF",
+                                "-DWITHOUT_SERVER=ON"
+                             ],
+                            "buildsystem": "cmake-ninja",
+                            "builddir": true,
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.19.tar.gz",
+                                    "sha256": "3622d2a53236ed9ca62de0616a7e80fd477a9a3f862ba09d503da188f53ca523"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "libjpeg-turbo",
+                            "config-opts": [ 
+                                "-DWITH_JPEG8=1"
+                             ],
+                            "cleanup": [ "/bin", "/share" ],
+                            "buildsystem": "cmake-ninja",
+                            "builddir": true,
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://downloads.sourceforge.net/project/libjpeg-turbo/2.0.4/libjpeg-turbo-2.0.4.tar.gz",
+                                    "sha256": "33dd8547efd5543639e890efbf2ef52d5a21df81faf41bb940657af916a23406"
+                                }
+                            ]
+                        }
                     ]
                 },
                 {
@@ -458,20 +766,7 @@
                         }
                     ],
                     "modules": [
-                        "shared-modules/glu/glu-9.json",
-                        {
-                            "name": "zstd",
-                            "buildsystem": "cmake-ninja",
-                            "config-opts": [ "-DCMAKE_BUILD_TYPE=Release" ],
-                            "subdir": "build/cmake",
-                            "sources": [
-                                {
-                                    "type": "git",
-                                    "url": "https://github.com/facebook/zstd.git",
-                                    "branch" : "v1.4.4"
-                                }
-                            ]
-                        }
+                        "shared-modules/glu/glu-9.json"
                     ]
                 },
                 {


### PR DESCRIPTION
Adds support for:

* WFS. This requires OGR Spatialite format support in GDAL which wasn't correctly built (#56) 
* JPEG2000 raster support
* GeoPDF exports from QGIS Print Layout (#50)
* ODBC/MySQL/MSSQL vector database support