### PR TITLE
Adding the latest patches for QGIS version 3.4

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -30,7 +30,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/qgis/QGIS.git",
-                    "branch" : "final-3_4_4"
+                    "branch" : "final-3_4_15"
                 }
             ],
             "config-opts" : [


### PR DESCRIPTION
It will be great if users have more versions of QGIS to choose for installation. This is just an update version QGIS from 3.4.4 to 3.4.15 with applied all patches.  If possible please add it in the flathub, so users don't need to built it. My opinion is that QGIS 3.4 was a very good and stable version, after this version the problems with porj4 begins - https://github.com/qgis/QGIS/issues/37809 https://github.com/qgis/QGIS/issues/33121 .