### PR TITLE
Fix crash when adding a jpeg/tiff raster layer

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -196,6 +196,7 @@
                     "config-opts" : [
                         "--with-python=python3",
                         "--with-libtiff=internal",
+                        "--with-jpeg=internal",
                         "--with-netcdf",
                         "--with-sqlite3",
                         "--with-geotiff=internal",


### PR DESCRIPTION
This builds gdal using the internal libjpeg rather than the one in the flatpak, otherwise this qgis will crash if the user attempts to add a tiff or jpeg raster layer.

I previously tried to fix this by using symlinks without success, the [gdal documentation](https://trac.osgeo.org/gdal/wiki/BuildingOnUnix) recommends this approach instead:

> The "autoconf" logic that checks for libtiff, libpng and libjpeg isn't too savvy about versions. If it is using pre-installed versions of these libraries and this support isn't working, rerun configure with "--with-png=internal", "--with-jpeg=internal", "--with-geotiff=internal" or "--with-libtiff=internal" instead. 

Also fixes #96 

