### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -1,9 +1,9 @@
 {
     "id": "org.qgis.qgis",
     "base": "io.qt.qtwebkit.BaseApp",
-    "base-version": "5.15",
+    "base-version": "5.15-21.08",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15",
+    "runtime-version": "5.15-21.08",
     "sdk": "org.kde.Sdk",
     "command": "qgis",
     "rename-icon": "qgis",


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostly similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.