### PR TITLE
Try to reduce the disk footprint

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -22,6 +22,14 @@
             "PYTHONPATH": "/app/lib/python3.9/site-packages:/usr/lib/python3.9/site-packages"
         }
     },
+    "cleanup" : [
+        "/lib/pkgconfig",
+        "/include",
+        "*.la",
+        "*.a",
+        "bin/mysql*",
+        "grass78/docs"
+    ],
     "modules": [
         {
             "name": "qgis",


### PR DESCRIPTION
There's clearly too much stuff in there that we don't need at runtime,
this is a first approach to trim it down.
Biggest culprits I've seen are:
- *.a files
- grass documentation
- bin/mysql binaries