### PR TITLE
Use MarkupSafe 2.0.1 (LTS branch)

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -978,8 +978,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://files.pythonhosted.org/packages/62/0f/52c009332fdadd484e898dc8f2acca0663c1031b3517070fd34ad9c1b64e/MarkupSafe-2.1.0.tar.gz",
-                            "sha256": "80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f"
+                            "url": "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz",
+                            "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
                         }
                     ],
                     "build-commands": [


### PR DESCRIPTION
See flathub@d738b80#r67361103, flathub#174, https://github.com/flathub/org.qgis.qgis/issues/174#issuecomment-1160557294, flathub#175, pallets/markupsafe#284