### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -14,7 +14,12 @@
         "--share=network",
         "--socket=wayland",
         "--socket=x11",
-        "--filesystem=host",
+        "--filesystem=home",
+        "--filesystem=/media",
+        "--filesystem=/mnt",
+        "--filesystem=/run/media",
+        "--filesystem=/var/run/media",
+        "--filesystem=/var/mnt",
         "--device=dri"
     ],
     "separate-locales": false,


### PR DESCRIPTION
it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt