### PR TITLE
fixed minizip url

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -118,7 +118,7 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://zlib.net/zlib-1.2.13.tar.gz",
+                            "url": "https://zlib.net/fossils/zlib-1.2.13.tar.gz",
                             "sha256": "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
                         },
                         {


### PR DESCRIPTION
When trying to build I got 404 error. It appears that the url changed. I see all versions under `/fossils`. We could also use GitHub release link. 