### PR TITLE
QGIS insists on having an X11 socket available

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -13,7 +13,7 @@
         "--share=ipc",
         "--share=network",
         "--socket=wayland",
-        "--socket=fallback-x11",
+        "--socket=x11",
         "--filesystem=host",
         "--device=dri"
     ],


### PR DESCRIPTION
Fixes #441