### PR TITLE
update sqlite version and enable ICU for full utf8 support

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -215,18 +215,15 @@
                         },
                         {
                             "name": "sqlite3",
-                            "config-opts": [
-                                "--disable-static",
-                                "--disable-amalgamation",
-                                "--enable-rtree",
-                                "--enable-json1",
-                                "CFLAGS=-DSQLITE_ENABLE_COLUMN_METADATA=1"
+                            "buildsystem": "simple",
+                            "build-commands": [
+                                "CFLAGS='-O2 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_ICU' CPPFLAGS=`icu-config --cppflags` LDFLAGS=`icu-config --ldflags` ./configure --disable-static --enable-rtree --prefix=/app && make && make install"
                             ],
                             "sources": [
                                 {
                                     "type": "archive",
-                                    "url": "https://www.sqlite.org/2024/sqlite-autoconf-3470000.tar.gz",
-                                    "sha256": "83eb21a6f6a649f506df8bd3aab85a08f7556ceed5dbd8dea743ea003fc3a957"
+                                    "url": "https://www.sqlite.org/2025/sqlite-autoconf-3490100.tar.gz",
+                                    "sha256": "106642d8ccb36c5f7323b64e4152e9b719f7c0215acf5bfeac3d5e7f97b59254"
                                 }
                             ]
                         }


### PR DESCRIPTION
- updated SQLite version from 3.47 to 3.49.1
- got rid of `configure` flags that were not recognized (json1 is supposedly built in now so the flag shouldn't be needed)
- enabled ICU so sqlite can fully support utf-8

From what I checked it worked. In current build query on spatialite:
```
select 'Ą' as a, lower('Ą') as aa
```
will return: ('Ą', 'Ą') but after compiling with ICU it will return ('Ą', 'ą').