### PR TITLE
Downgrade libspatialindex to 2.0.0 (libspatialindex 2.1.0 breaks nearest neighbor calculations in QGIS)

### DIFF
--- a/org.qgis.qgis.json
+++ b/org.qgis.qgis.json
@@ -116,9 +116,6 @@
                             "url": "https://github.com/libspatialindex/libspatialindex.git",
                             "commit": "4a3bd449b9f2858d31a4619ba60bae6d1d30b77d",
                             "tag": "2.0.0",
-                            "x-checker-data": {
-                                "type": "git"
-                            }
                         }
                     ]
                 },


### PR DESCRIPTION
Fixes #949.